### PR TITLE
Shorten module names for FreeBSD.

### DIFF
--- a/i915kmsfw/bxthuc/Makefile
+++ b/i915kmsfw/bxthuc/Makefile
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-KMOD	= i915_bxt_huc_ver01_07_1398_bin
-NAME	= i915/bxt_huc_ver01_07_1398.bin
+KMOD	= i915_bxt_huc_ver01_07_bin
+NAME	= i915/bxt_huc_ver01_07.bin
 IMG	= bxt_huc_ver01_07_1398
 .include <bsd.kmod.mk>

--- a/i915kmsfw/kblhuc/Makefile
+++ b/i915kmsfw/kblhuc/Makefile
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-KMOD	= i915_kbl_huc_ver02_00_1810_bin
-NAME	= i915/kbl_huc_ver02_00_1810.bin
+KMOD	= i915_kbl_huc_ver02_00_bin
+NAME	= i915/kbl_huc_ver02_00.bin
 IMG	= kbl_huc_ver02_00_1810
 .include <bsd.kmod.mk>

--- a/i915kmsfw/sklhuc/Makefile
+++ b/i915kmsfw/sklhuc/Makefile
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-KMOD	= i915_skl_huc_ver01_07_1398_bin
-NAME	= i915/skl_huc_ver01_07_1398.bin
+KMOD	= i915_skl_huc_ver01_07_bin
+NAME	= i915/skl_huc_ver01_07.bin
 IMG	= skl_huc_ver01_07_1398
 .include <bsd.kmod.mk>


### PR DESCRIPTION
These newly added firmware modules have very long names but FreeBSD module
name cannot be this long.  Work around it by omitting build numbers.