### PR TITLE
Make this build on all platforms.  This is needed because drm-legacy-…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,9 @@
 SYSDIR?=/usr/src/sys
 .include "${SYSDIR}/conf/kern.opts.mk"
 
-.if ${MACHINE_CPUARCH} == "amd64"
 _amdgpukmsfw=	amdgpukmsfw
 _i915kmsfw=	i915kmsfw
 _radeonkmsfw=	radeonkmsfw
-.endif
 
 SUBDIR = \
 	${_i915kmsfw} \


### PR DESCRIPTION
…kmod

uses these firmware files, and that is available on multiple platforms.

This replaces the port patch this I posted on developers@.