### PR TITLE
Update firmware(9) image names.

### DIFF
--- a/amdgpukmsfw/Makefile.inc
+++ b/amdgpukmsfw/Makefile.inc
@@ -8,15 +8,14 @@ _NAME=		amdgpu_${NAME}_bin
 
 KMOD=	${_NAME}
 
-FIRMWS=	${FWFILE}:amdgpu/${FWFILE}
+FIRMWS=	${_NAME}:${_NAME}
 
 #
 # Note that a license ack is not needed for amdgpu 
 #
 #FIRMWARE_LICENSE=
 
-CLEANFILES+=	${FWFILE}
 CLEANFILES+=	${_NAME} ${_NAME}.fwo ${_NAME}.ko.debug ${_NAME}.ko.full
 
-${FWFILE}: ${.CURDIR}/../../amdgpukmsfw-files/${FWFILE}.uu
+${_NAME}: ${.CURDIR}/../../amdgpukmsfw-files/${FWFILE}.uu
 	uudecode -p $? > ${.TARGET}

--- a/i915kmsfw/Makefile.inc
+++ b/i915kmsfw/Makefile.inc
@@ -9,15 +9,14 @@ _NAME=		i915_${NAME}_ver${VERSION}_bin
 
 KMOD=	${_NAME}
 
-FIRMWS=	${FWFILE}:i915/${NAME}_ver${VERSION}.bin
+FIRMWS=	${_NAME}:${_NAME}
 
 #
 # Note that a license ack is not needed for i915kms.
 #
 #FIRMWARE_LICENSE=
 
-CLEANFILES+=	${FWFILE}
 CLEANFILES+=	${_NAME} ${_NAME}.fwo ${_NAME}.ko.debug ${_NAME}.ko.full
 
-${FWFILE}: ${.CURDIR}/../../i915kmsfw-files/${FWFILE}.uu
+${_NAME}: ${.CURDIR}/../../i915kmsfw-files/${FWFILE}.uu
 	uudecode -p $? > ${.TARGET}

--- a/radeonkmsfw/Makefile.inc
+++ b/radeonkmsfw/Makefile.inc
@@ -8,15 +8,14 @@ _NAME=		radeon_${NAME}_bin
 
 KMOD=	${_NAME}
 
-FIRMWS=	${FWFILE}:radeon/${FWFILE}
+FIRMWS=	${_NAME}:${_NAME}
 
 #
 # Note that a license ack is not needed for radeon.
 #
 #FIRMWARE_LICENSE=
 
-CLEANFILES+=	${FWFILE}
 CLEANFILES+=	${_NAME} ${_NAME}.fwo ${_NAME}.ko.debug ${_NAME}.ko.full
 
-${FWFILE}: ${.CURDIR}/../../radeonkmsfw-files/${FWFILE}.uu
+${_NAME}: ${.CURDIR}/../../radeonkmsfw-files/${FWFILE}.uu
 	uudecode -p $? > ${.TARGET}


### PR DESCRIPTION
Based on manu's comments in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=251415#c5
resubmit this change, which previously was part of
https://github.com/FreeBSDDesktop/kms-firmware/pull/13
to be included in the main kms-firmware repo.

This change will adjust the firmware image name to the firmware
kernel module file name and with that will allow firmware(9)
as-is to auto-load the the kernel module without any extra logic
needed for firmare(9)/kernel linker.

Sposnored by:	The FreeBSD Foundation